### PR TITLE
convert ncessch_num from float to double to fix precision issue

### DIFF
--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -36,8 +36,8 @@ mata
 			varinfo[1,r] = trow->getString("variable", "")
 			varinfo[2,r] = trow->getString("label", "")
 			tempvar = trow->getString("data_type", "")
-			if (tempvar == "integer") varinfo[3,r] = "float"
-			else if (tempvar == "float") varinfo[3,r] = "double"
+			if ((tempvar == "integer") && (varinfo[1,r] != "ncessch_num")) varinfo[3,r] = "float"
+			else if ((tempvar == "float") || (varinfo[1,r] == "ncessch_num")) varinfo[3,r] = "double"
 			else if (tempvar == "string"){ 
 				varinfo[3,r] = "str" + trow->getString("string_length", "")
 			}

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -982,8 +982,6 @@ mata
 				if (validfilters == "") validfilters = varinfo[1,c]
 				else validfilters = validfilters + ", " + varinfo[1,c]
 			}
-			printf("validfitler\n")
-			printf(validfilters)
 		}
 		t = tokeninit(", ")
 		s = tokenset(t, validfilters)

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -36,9 +36,8 @@ mata
 			varinfo[1,r] = trow->getString("variable", "")
 			varinfo[2,r] = trow->getString("label", "")
 			tempvar = trow->getString("data_type", "")
-			if ((tempvar == "integer") && (varinfo[1,r] != "ncessch_num")) varinfo[3,r] = "float"
-			else if ((tempvar == "float") || (varinfo[1,r] == "ncessch_num")) varinfo[3,r] = "double"
-			else if (tempvar == "string"){ 
+			if (tempvar == "integer" || tempvar == "float") varinfo[3,r] = "double"
+			else if (tempvar == "string"){
 				varinfo[3,r] = "str" + trow->getString("string_length", "")
 			}
 			varinfo[5,r] = trow->getString("format", "")
@@ -978,11 +977,13 @@ mata
 			varinfo[1,c] = strlower(varinfo[1,c])
 		}
 		validfilters = ""
-		for (c=1; c<=length(varinfo[6,.]); c++){
-			if (varinfo[6,c] == "1" && varinfo[3,c] == "float"){
+		for (c=1; c<=length(varinfo[6,.]); c++){    /* varinfo[6,c] indicates is_filter */ 
+			if (varinfo[6,c] == "1" && varinfo[3,c] == "double"){       /* note that no float variables are filters per metadata */ 
 				if (validfilters == "") validfilters = varinfo[1,c]
 				else validfilters = validfilters + ", " + varinfo[1,c]
 			}
+			printf("validfitler\n")
+			printf(validfilters)
 		}
 		t = tokeninit(", ")
 		s = tokenset(t, validfilters)


### PR DESCRIPTION
Variable `ncessch_num` was defined as `float` in STATA; but since `float` only has [7 digits of accuracy](https://www.stata.com/manuals13/ddatatypes.pdf), and `ncessch_num` usually has 11 or 12 digits, we convert it to `double`, which has 16 digits of accuracy. 