### PR TITLE
Updates to EDP Stata Package

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,13 @@
 # Changelog for educationdata Stata Package
 
-#### 0.4.2 (Development Version, not yet released)
+#### 0.4.2 (2022-08-02)
 
-#### 0.4.1 (Current Stable Version)
+- Report package version 
+- Add example using multiple filters in summary endpoints to documentation
+- Fix error from aggregating by only year in summary endpoints 
+
+
+#### 0.4.1 
 
 - Update package to incorporate new endpoints and add new years to existing endpoints from latest release 
 - Fix value labeling issue by adding replace option
@@ -13,7 +18,7 @@
 - Fix missing value labels in summary endpoints 
 - Add error handling in summary endpoints 
 
-#### 0.3.9 (Current Stable Version)
+#### 0.3.9 
 
 - Update package to incorporate new endpoints from latest release 
 - Add summaries option to allow access to the new summary endpoint functionality 

--- a/docs/educationdata.ado
+++ b/docs/educationdata.ado
@@ -1,4 +1,4 @@
-*! version 0.4.1
+*! version 0.4.2
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");

--- a/docs/educationdata.ado
+++ b/docs/educationdata.ado
@@ -1,3 +1,4 @@
+*! version 0.4.1
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");
@@ -1110,6 +1111,7 @@ mata
 		token_cmd = tokens(summaries)
 		var_to_agg = token_cmd[2]
 		agg_by = ""
+		token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","

--- a/docs/educationdata.sthlp
+++ b/docs/educationdata.sthlp
@@ -49,6 +49,9 @@
 
     Download the average number of students who took at least one AP exams by race and disability in each year: 
     . educationdata using "school crdc ap-exams", summaries(avg students_AP_exam_oneormore by race disability)
+	
+	Download IB enrollment totals by Office of Civil Rights school ID in 2017 for the state of New York only:
+	. educationdata using "school crdc ap-ib-enrollment", summaries(sum enrl_IB by crdc_id) sub(year=2017&fips=36)
 
 {bf:Getting only metadata}:
 
@@ -1008,6 +1011,15 @@ For example,
 
 This command takes the "schools/ccd/enrollment" endpoint, retrieves the sum of school enrollment 
 by fips code, and filters to year 2000. 
+
+Filters can also be applied to summary statistics using the "sub" command.  The arguments are structured as 
+"sub(variable=value))", where multiple filters are separated by "&".
+For example,
+
+. educationdata using "school crdc ap-ib-enrollment", summaries(sum enrl_IB by crdc_id) sub(year=2017&fips=36)
+
+This command takes the "schools/crdc/ap-ib-enrollment" endpoint, retrieves the sum of IB enrollment by Office of 
+Civil Rights school ID in 2017 for the state of New York.
 
 More detailed instructions can be found in {browse "https://educationdata.urban.org/documentation":Education Data Portal Documentation}. 
 

--- a/educationdata/edp-stata-testing.do
+++ b/educationdata/edp-stata-testing.do
@@ -1,0 +1,1 @@
+educationdata using "school ccd enrollment", summaries(sum enrollment using fips race) sub(year=2018&fips=11)

--- a/educationdata/edp-stata-testing.do
+++ b/educationdata/edp-stata-testing.do
@@ -1,1 +1,0 @@
-educationdata using "school ccd enrollment", summaries(sum enrollment using fips race) sub(year=2018&fips=11)

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -795,7 +795,7 @@ mata
 		}
 		
 		ep_url = ep_url + "?stat=" + agg_method + "&by=" + agg_by + "&var=" + var_to_agg
-
+		
 		return(ep_url)
 	}
 

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -785,7 +785,7 @@ mata
 		agg_method = token_cmd[1]   
 		var_to_agg = token_cmd[2]
 		agg_by = ""
-		
+
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
@@ -793,6 +793,7 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}
+		
 		ep_url = ep_url + "?stat=" + agg_method + "&by=" + agg_by + "&var=" + var_to_agg
 
 		return(ep_url)

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -1,4 +1,4 @@
-*! version 0.4.1 - TESTING
+*! version 0.4.1
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");
@@ -245,9 +245,9 @@ mata
 	// Helper function to add mode logging to URLs for API tracking
 	string scalar urlmode(string scalar url3){
 		string scalar strnum
-		if (strpos(url3, "mode=testing") == 0){
-			if (subinstr(url3, "?", "") == url3) url3 = url3 + "?mode=testing"
-			else url3 = url3 + "&mode=testing"
+		if (strpos(url3, "mode=stata") == 0){
+			if (subinstr(url3, "?", "") == url3) url3 = url3 + "?mode=stata"
+			else url3 = url3 + "&mode=stata"
 		}
 		strnum = strofreal(round(runiform(1,1)*100000))
 		if (st_global("cc") == "1") url3 = url3 + "&a=" + strnum
@@ -1114,15 +1114,7 @@ mata
 		var_to_agg = token_cmd[2]
 		agg_by = ""
 		
-		// printf("\n ---before substitution---")
-		// token_cmd
-		// printf("\n ---")
-
-		// printf("\n ---substitute 'year' in token_cmd if it exists---")
 		token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
-		// printf("\n ---after substitution---")
-		// token_cmd
-		// printf("\n ---")
 		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
@@ -1131,15 +1123,13 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}  
-// 		printf("\n --- agg_by: %s", agg_by)
+
 		if (strmatch(agg_by, "*,*") == 1) {
 			groupby_lst = tokens(agg_by, ",")
 		} else {
 			groupby_lst = tokens(agg_by)
 		}
-// 		printf("\n --- FINAL GROUP BY LIST--- \n")
-// 		groupby_lst
-// 		printf("\n ---")
+
 		varinfo1 = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=year")
 		varinfo_var_to_agg = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=" + var_to_agg)
 		num_var = 2 + (length(groupby_lst) + 1)/2

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -785,17 +785,14 @@ mata
 		agg_method = token_cmd[1]   
 		var_to_agg = token_cmd[2]
 		agg_by = ""
-
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
 			} else {
 				agg_by = agg_by + token_cmd[c]
 			}
-		}
-		
+		}   
 		ep_url = ep_url + "?stat=" + agg_method + "&by=" + agg_by + "&var=" + var_to_agg
-		
 		return(ep_url)
 	}
 

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -1,4 +1,4 @@
-*! version 0.4.1
+*! version 0.4.1 - TESTING
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");
@@ -1108,6 +1108,7 @@ mata
 		for (i=1; i<=length(allopts); i++){
 			summary_ep_url = summary_ep_url + "&" + allopts[i]
 		}
+	
 		printf("\n\nGetting data from: " + st_global("base_url") + summary_ep_url + "\n")
 		token_cmd = tokens(summaries)
 		var_to_agg = token_cmd[2]

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -785,7 +785,7 @@ mata
 		agg_method = token_cmd[1]   
 		var_to_agg = token_cmd[2]
 		agg_by = ""
-		
+
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
@@ -793,9 +793,9 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}   
-		
+
 		ep_url = ep_url + "?stat=" + agg_method + "&by=" + agg_by + "&var=" + var_to_agg
-		
+
 		return(ep_url)
 	}
 

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -1,4 +1,4 @@
-*! version 0.4.1 (v2)
+*! version 0.4.1
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");
@@ -1117,6 +1117,8 @@ mata
 		token_cmd
 		printf("\n ---")
 		
+		/* if the data source is "school ccd enrollment" and year is a "by variable", 
+		   remove it since year is a default by-variable for this data source*/
 		if (dataoptions == "schools ccd enrollment"){
 			printf("\n ---substitute 'year' in token_cmd if it exists---")
 			token_cmd = select(token_cmd, token_cmd[1,.]:!="year")

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -774,7 +774,6 @@ mata
 		string scalar var_to_agg
 		string scalar agg_by
 		string rowvector token_cmd
-		
 
 		ep_url = "/api/v1/"    
 		for (c=1; c<=length(tokens(dataoptions)); c++){   
@@ -1102,20 +1101,16 @@ mata
 		real scalar tempdata
 		real scalar totallen
 		real scalar epcount
-
 		summary_ep_url = getsummariesurl(dataoptions, summaries)
 		allopts = tokens(opts)
 		for (i=1; i<=length(allopts); i++){
 			summary_ep_url = summary_ep_url + "&" + allopts[i]
 		}
-	
 		printf("\n\nGetting data from: " + st_global("base_url") + summary_ep_url + "\n")
 		token_cmd = tokens(summaries)
 		var_to_agg = token_cmd[2]
 		agg_by = ""
-		
 		token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
-		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
@@ -1123,13 +1118,11 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}  
-
 		if (strmatch(agg_by, "*,*") == 1) {
 			groupby_lst = tokens(agg_by, ",")
 		} else {
 			groupby_lst = tokens(agg_by)
 		}
-
 		varinfo1 = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=year")
 		varinfo_var_to_agg = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=" + var_to_agg)
 		num_var = 2 + (length(groupby_lst) + 1)/2

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -1,4 +1,4 @@
-*! version 0.4.1
+*! version 0.4.2
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -1,3 +1,4 @@
+*! version 0.4.1 (v2)
 program educationdata
 version 11.0
 mata: if (findfile("libjson.mlib") != "") {} else stata("ssc install libjson");
@@ -773,6 +774,7 @@ mata
 		string scalar var_to_agg
 		string scalar agg_by
 		string rowvector token_cmd
+		
 
 		ep_url = "/api/v1/"    
 		for (c=1; c<=length(tokens(dataoptions)); c++){   
@@ -784,15 +786,14 @@ mata
 		agg_method = token_cmd[1]   
 		var_to_agg = token_cmd[2]
 		agg_by = ""
-
+		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
 			} else {
 				agg_by = agg_by + token_cmd[c]
 			}
-		}   
-
+		}
 		ep_url = ep_url + "?stat=" + agg_method + "&by=" + agg_by + "&var=" + var_to_agg
 
 		return(ep_url)
@@ -1101,6 +1102,7 @@ mata
 		real scalar tempdata
 		real scalar totallen
 		real scalar epcount
+
 		summary_ep_url = getsummariesurl(dataoptions, summaries)
 		allopts = tokens(opts)
 		for (i=1; i<=length(allopts); i++){
@@ -1110,6 +1112,19 @@ mata
 		token_cmd = tokens(summaries)
 		var_to_agg = token_cmd[2]
 		agg_by = ""
+		
+		printf("\n ---before substitution---")
+		token_cmd
+		printf("\n ---")
+		
+		if (dataoptions == "schools ccd enrollment"){
+			printf("\n ---substitute 'year' in token_cmd if it exists---")
+			token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
+			printf("\n ---after substitution---")
+			token_cmd
+			printf("\n ---")
+		}
+		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
@@ -1117,11 +1132,15 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}  
+		printf("\n --- agg_by: %s", agg_by)
 		if (strmatch(agg_by, "*,*") == 1) {
 			groupby_lst = tokens(agg_by, ",")
 		} else {
 			groupby_lst = tokens(agg_by)
 		}
+		printf("\n --- FINAL GROUP BY LIST--- \n")
+		groupby_lst
+		printf("\n ---")
 		varinfo1 = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=year")
 		varinfo_var_to_agg = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=" + var_to_agg)
 		num_var = 2 + (length(groupby_lst) + 1)/2

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -1119,13 +1119,18 @@ mata
 		
 		/* if the data source is "school ccd enrollment" and year is a "by variable", 
 		   remove it since year is a default by-variable for this data source*/
-		if (dataoptions == "schools ccd enrollment"){
+		/*if (dataoptions == "schools ccd enrollment"){
 			printf("\n ---substitute 'year' in token_cmd if it exists---")
 			token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
 			printf("\n ---after substitution---")
 			token_cmd
 			printf("\n ---")
-		}
+		}*/
+		printf("\n ---substitute 'year' in token_cmd if it exists---")
+		token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
+		printf("\n ---after substitution---")
+		token_cmd
+		printf("\n ---")
 		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -245,9 +245,9 @@ mata
 	// Helper function to add mode logging to URLs for API tracking
 	string scalar urlmode(string scalar url3){
 		string scalar strnum
-		if (strpos(url3, "mode=stata") == 0){
-			if (subinstr(url3, "?", "") == url3) url3 = url3 + "?mode=stata"
-			else url3 = url3 + "&mode=stata"
+		if (strpos(url3, "mode=testing") == 0){
+			if (subinstr(url3, "?", "") == url3) url3 = url3 + "?mode=testing"
+			else url3 = url3 + "&mode=testing"
 		}
 		strnum = strofreal(round(runiform(1,1)*100000))
 		if (st_global("cc") == "1") url3 = url3 + "&a=" + strnum
@@ -1113,24 +1113,15 @@ mata
 		var_to_agg = token_cmd[2]
 		agg_by = ""
 		
-		printf("\n ---before substitution---")
-		token_cmd
-		printf("\n ---")
-		
-		/* if the data source is "school ccd enrollment" and year is a "by variable", 
-		   remove it since year is a default by-variable for this data source*/
-		/*if (dataoptions == "schools ccd enrollment"){
-			printf("\n ---substitute 'year' in token_cmd if it exists---")
-			token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
-			printf("\n ---after substitution---")
-			token_cmd
-			printf("\n ---")
-		}*/
-		printf("\n ---substitute 'year' in token_cmd if it exists---")
+		// printf("\n ---before substitution---")
+		// token_cmd
+		// printf("\n ---")
+
+		// printf("\n ---substitute 'year' in token_cmd if it exists---")
 		token_cmd = select(token_cmd, token_cmd[1,.]:!="year")
-		printf("\n ---after substitution---")
-		token_cmd
-		printf("\n ---")
+		// printf("\n ---after substitution---")
+		// token_cmd
+		// printf("\n ---")
 		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
@@ -1139,15 +1130,15 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}  
-		printf("\n --- agg_by: %s", agg_by)
+// 		printf("\n --- agg_by: %s", agg_by)
 		if (strmatch(agg_by, "*,*") == 1) {
 			groupby_lst = tokens(agg_by, ",")
 		} else {
 			groupby_lst = tokens(agg_by)
 		}
-		printf("\n --- FINAL GROUP BY LIST--- \n")
-		groupby_lst
-		printf("\n ---")
+// 		printf("\n --- FINAL GROUP BY LIST--- \n")
+// 		groupby_lst
+// 		printf("\n ---")
 		varinfo1 = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=year")
 		varinfo_var_to_agg = getvarinfo(st_global("base_url") + "/api/v1/api-variables/?variable=" + var_to_agg)
 		num_var = 2 + (length(groupby_lst) + 1)/2

--- a/educationdata/educationdata.ado
+++ b/educationdata/educationdata.ado
@@ -785,6 +785,7 @@ mata
 		agg_method = token_cmd[1]   
 		var_to_agg = token_cmd[2]
 		agg_by = ""
+		
 		for (c=4; c<=length(token_cmd); c++){
 			if (c != length(token_cmd)){
 				agg_by = agg_by + token_cmd[c] + ","
@@ -792,7 +793,9 @@ mata
 				agg_by = agg_by + token_cmd[c]
 			}
 		}   
+		
 		ep_url = ep_url + "?stat=" + agg_method + "&by=" + agg_by + "&var=" + var_to_agg
+		
 		return(ep_url)
 	}
 

--- a/educationdata/educationdata.sthlp
+++ b/educationdata/educationdata.sthlp
@@ -49,6 +49,9 @@
 
     Download the average number of students who took at least one AP exams by race and disability in each year: 
     . educationdata using "school crdc ap-exams", summaries(avg students_AP_exam_oneormore by race disability)
+	
+	Download IB enrollment totals by Office of Civil Rights school ID in 2017 for the state of New York only:
+	. educationdata using "school crdc ap-ib-enrollment", summaries(sum enrl_IB by crdc_id) sub(year=2017&fips=36)
 
 {bf:Getting only metadata}:
 
@@ -1008,6 +1011,15 @@ For example,
 
 This command takes the "schools/ccd/enrollment" endpoint, retrieves the sum of school enrollment 
 by fips code, and filters to year 2000. 
+
+Filters can also be applied to summary statistics using the "sub" command.  The arguments are structured as 
+"sub(variable=value))", where multiple filters are separated by "&".
+For example,
+
+. educationdata using "school crdc ap-ib-enrollment", summaries(sum enrl_IB by crdc_id) sub(year=2017&fips=36)
+
+This command takes the "schools/crdc/ap-ib-enrollment" endpoint, retrieves the sum of IB enrollment by Office of 
+Civil Rights school ID in 2017 for the state of New York.
 
 More detailed instructions can be found in {browse "https://educationdata.urban.org/documentation":Education Data Portal Documentation}. 
 


### PR DESCRIPTION
This pull requests reflects the following changes to the EDP Stata package:

1. Resolved the error that arises from calling summary endpoints that are summarized by the year variable.  Closes #86.
2. Package version number is now displayed when calling `which educationdata`.  Closes #84.
3. Package documentation now includes examples of summary endpoints with multiple filters.  Closes #87.